### PR TITLE
Create Preview Section of All Pages (desktop + mobile)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,6 @@ import OverviewText from "./components/OverviewText";
 import PagePreview from "./components/PagePreview";
 
 function App() {
-  const hello = 5;
   return (
     <div className="App">
       <Header />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,16 @@ import React from "react";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import OverviewText from "./components/OverviewText";
+import PagePreview from "./components/PagePreview";
 
 function App() {
   const hello = 5;
   return (
     <div className="App">
       <Header />
-      <OverviewText /> <Footer />
+      <OverviewText />
+      <PagePreview />
+      <Footer />
     </div>
   );
 }

--- a/src/components/PagePreview.tsx
+++ b/src/components/PagePreview.tsx
@@ -1,46 +1,89 @@
 import React from "react";
 import styled from "styled-components";
-import { fontColor, vizColors } from "../styling/stylingConstants";
+import {
+  fontColor,
+  vizColors,
+  mobileBreakpoint,
+  maxWidth,
+} from "../styling/stylingConstants";
 
 const PageCardWrapper = styled.div`
-  height: 446px;
-  border-left: 2px solid ${fontColor};
-  width: auto;
+  border-bottom: 2px solid ${fontColor};
+  border-left: 0px;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  @media only screen and (min-width: ${mobileBreakpoint}) {
+    border-left: 2px solid ${fontColor};
+    flex-direction: column;
+  }
+
+  :nth-last-child(2) {
+    border-bottom: 0px;
+  }
 
   :first-child {
-    margin-left: calc((100vw - 1170px) / 2);
+    margin-left: 0px;
+    border-left: 0px;
+    @media only screen and (min-width: ${maxWidth}) {
+      border-left: 2px solid ${fontColor};
+      margin-left: calc(50vw - 585px);
+    }
   }
 
   h3 {
     font-family: Outfit;
     font-weight: 500;
     font-size: 24px;
-    margin: 24px 24px 0px 24px;
+    margin: 16px;
+    @media only screen and (min-width: ${mobileBreakpoint}) {
+      margin: 24px 24px 0px 24px;
+    }
   }
   p {
-    margin: 24px;
+    display: none;
+    @media only screen and (min-width: ${mobileBreakpoint}) {
+      margin: 24px;
+      display: block;
+    }
   }
 `;
 
 const ColorImageWrapper = styled.div`
-  min-width: 360px;
-  height: 100%;
+  min-width: 40px;
+  min-height: 100%;
+  flex-grow: 1;
   background: ${(props) => props.color};
+  @media only screen and (min-width: ${mobileBreakpoint}) {
+    width: 100%;
+    min-width: 360px;
+    height: 100%;
+  }
 `;
+
+// this is the right hand side spacer; also serves to set height for pagecards
 const MarginPageCard = styled.div`
-  height: 446px;
+  display: none;
   min-width: calc((100vw - 1170px) / 2);
-  border-left: 2px solid ${fontColor};
-  background: white;
+  border-left: 0px;
+  @media only screen and (min-width: ${mobileBreakpoint}) {
+    display: block;
+    height: 446px;
+  }
+  @media only screen and (min-width: ${maxWidth}) {
+    border-left: 2px solid ${fontColor};
+  }
 `;
 
 const CardHorizontal = styled.div`
   overflow-x: scroll;
+  overflow-y: hidden;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   border: 2px solid ${fontColor};
+  @media only screen and (min-width: ${mobileBreakpoint}) {
+    flex-direction: row;
+    max-height: 446px;
+  }
 `;
 type ImageSizes = "big" | "small";
 
@@ -59,7 +102,6 @@ function PageCard({
 }) {
   return (
     <PageCardWrapper>
-      {" "}
       <h3>{title}</h3>
       <p>{bodyCopy}</p>
       <ColorImage size="big" color={color} />

--- a/src/components/PagePreview.tsx
+++ b/src/components/PagePreview.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import styled from "styled-components";
+import { fontColor, vizColors } from "../styling/stylingConstants";
+
+const PageCardWrapper = styled.div`
+  height: 446px;
+  border-left: 2px solid ${fontColor};
+  width: auto;
+  display: flex;
+  flex-direction: column;
+
+  :first-child {
+    margin-left: calc((100vw - 1170px) / 2);
+  }
+
+  h3 {
+    font-family: Outfit;
+    font-weight: 500;
+    font-size: 24px;
+    margin: 24px 24px 0px 24px;
+  }
+  p {
+    margin: 24px;
+  }
+`;
+
+const ColorImageWrapper = styled.div`
+  min-width: 360px;
+  height: 100%;
+  background: ${(props) => props.color};
+`;
+const MarginPageCard = styled.div`
+  height: 446px;
+  min-width: calc((100vw - 1170px) / 2);
+  border-left: 2px solid ${fontColor};
+  background: white;
+`;
+
+const CardHorizontal = styled.div`
+  overflow-x: scroll;
+  display: flex;
+  flex-direction: row;
+  border: 2px solid ${fontColor};
+`;
+type ImageSizes = "big" | "small";
+
+function ColorImage({ size, color }: { size: ImageSizes; color: string }) {
+  return <ColorImageWrapper color={color} />;
+}
+
+function PageCard({
+  title,
+  bodyCopy,
+  color,
+}: {
+  title: string;
+  bodyCopy: string;
+  color: string;
+}) {
+  return (
+    <PageCardWrapper>
+      {" "}
+      <h3>{title}</h3>
+      <p>{bodyCopy}</p>
+      <ColorImage size="big" color={color} />
+    </PageCardWrapper>
+  );
+}
+
+export default function PagePreview() {
+  const placeholderCopy =
+    "How countries around the world write today’s date. Month first? Day first? Everyone has an opinion. ";
+  return (
+    <CardHorizontal>
+      <PageCard
+        title="Date Formats"
+        bodyCopy={placeholderCopy + placeholderCopy}
+        color={vizColors.yellow}
+      />
+      <PageCard
+        title="Second"
+        bodyCopy={placeholderCopy}
+        color={vizColors.adamantineBlue}
+      />
+      <PageCard
+        title="Third"
+        bodyCopy={placeholderCopy}
+        color={vizColors.brightGreen}
+      />
+      <PageCard
+        title="Date Another"
+        bodyCopy={placeholderCopy}
+        color={vizColors.pastelPurple}
+      />
+      <PageCard
+        title="Fourth Formats"
+        bodyCopy={placeholderCopy}
+        color={vizColors.adamantineBlue}
+      />
+      <MarginPageCard />
+    </CardHorizontal>
+  );
+}

--- a/src/components/Tooltips.tsx
+++ b/src/components/Tooltips.tsx
@@ -1,10 +1,7 @@
 import React, { useState } from "react";
 import styled from "styled-components";
-
+import { vizColors } from "../styling/stylingConstants";
 // reference: https://paladini.dev/posts/how-to-make-an-extremely-reusable-tooltip-component-with-react--and-nothing-else/
-const textColor = "black";
-const background = "white";
-const arrowsize = "6px";
 
 const TooltipWrapper = styled.div`
   display: inline-block;
@@ -27,7 +24,7 @@ const TooltipTip = styled.div`
   }
 `;
 const ColorDiv = styled.div`
-  background: #4badf8;
+  background: ${vizColors.adamantineBlue};
   font-family: Outfit;
   font-size: 24px;
   font-weight: 500;

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -2,6 +2,7 @@ import { ReportHandler } from "web-vitals";
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     import("web-vitals").then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
       getCLS(onPerfEntry);
       getFID(onPerfEntry);

--- a/src/styling/stylingConstants.tsx
+++ b/src/styling/stylingConstants.tsx
@@ -5,4 +5,21 @@ export const tabletBreakpoint = "768px";
 export const maxWidth = "1170px";
 export const h2 = "24px";
 export const heroText = "32px";
+
+/* Colors */
 export const fontColor = "#000";
+// export const yellow = "#F9D147";
+// export const brightGreen = "#9BE400";
+// export const adamantineBlue = "#4BADF8";
+// export const pastelPurple = "#9980FA";
+// export const pink = "#FA80D8";
+// export const neonSeaFoam = "#1ADB9A";
+
+export const vizColors = {
+  yellow: "#F9D147",
+  brightGreen: "#9BE400",
+  adamantineBlue: "#4BADF8",
+  pastelPurple: "#9980FA",
+  pink: "#FA80D8",
+  neonSeaFoam: "#1ADB9A",
+};

--- a/src/styling/stylingConstants.tsx
+++ b/src/styling/stylingConstants.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 
 export const tabletBreakpoint = "768px";
+export const mobileBreakpoint = "480px";
 export const maxWidth = "1170px";
 export const h2 = "24px";
 export const heroText = "32px";


### PR DESCRIPTION
This PR goes over the all page preview section. This compoennt both lives on the front page but can also be used at the bottom of all the detail pages except of the fact that filtering out the current page from the list has not been implemented/ thought through.

A group of "Page Cards" are organized in a horizontal scroll div on desktip and when the screen size dips below mobileBreakpoint, the cards transform into screen width sections w/o a description. To avoid using a window size event, all the styling changes are done in css rather than switching out the components at a certain breakpoint.